### PR TITLE
188663-disable-encryption: conditional based on a new homeserver.yaml…

### DIFF
--- a/Design/Design - 188663-disable-encryption.txt
+++ b/Design/Design - 188663-disable-encryption.txt
@@ -1,7 +1,7 @@
 188663-disable-encryption
 =================================================================
 
-To minimise the merge maintenance that this solution introduces, I was initially going to do the third party rules impl (see https://github.com/matrix-org/synapse/issues/4367#issuecomment-678366829 and https://github.com/matrix-org/synapse/issues/6660#issuecomment-738011092), until I saw that an additional change to rooms.py was also required.  This change could be pushed back to https://github.com/matrix-org/synapse and potentially address https://github.com/matrix-org/synapse/issues/4401. 
+To minimise the merge maintenance that this solution introduces, I was initially going to do the third party rules impl (see https://github.com/matrix-org/synapse/issues/4367#issuecomment-678366829 and https://github.com/matrix-org/synapse/issues/6660#issuecomment-738011092), until I saw that an additional change to rooms.py was also required which increases merge conflict from matrix master if this methodology is used. In long term this could be implemented and this change could be pushed back to https://github.com/matrix-org/synapse and potentially address https://github.com/matrix-org/synapse/issues/4401. 
 
 Based on https://github.com/matrix-org/synapse/issues/4367#issuecomment-452772632, encryption was disabled by setting the required power level to enable encryption for a room to be an impossible value, when creating a new room.  Noting that this means the disabling of encryption will only affect rooms created after this change.  It will also not affect rooms created by other servers, if federation is enabled.
  
@@ -12,7 +12,7 @@ Both of the above two changes are conditional based on a new homeserver.yaml con
 Based on
 1. https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md#disabling-encryption-by-default
 2. https://github.com/matrix-org/matrix-react-sdk/pull/4605/files
-the /.well-known/matrix/client was updated to indicate to clients if encryption is enabled.  Noting that as mentioned at https://github.com/vector-im/element-web/issues/14079#issuecomment-775180051, clients use the "default_server_config" -> "m.homeserver" -> "server_name" as the domain name in the lookup of /.well-known/matrix/client.  If this is different to the domain in "default_server_config" -> "m.homeserver" -> "base_url", it is suggested that your client is updated to check the "base_url" locartion if the well-known config is not found for "server_name".
+the /.well-known/matrix/client was updated to indicate to clients if encryption is enabled.  Noting that as mentioned at https://github.com/vector-im/element-web/issues/14079#issuecomment-775180051, clients use the "default_server_config" -> "m.homeserver" -> "server_name" as the domain name in the lookup of /.well-known/matrix/client.  If this is different to the domain in "default_server_config" -> "m.homeserver" -> "base_url", it is suggested that your client is updated to check the "base_url" location if the well-known config is not found for "server_name".
 
 These changes to the source code were applied to the synapse docker image, by copying the modified source over the top of the existing files.  This method only works if the changes made to the source code don't introduce new dependencies, that the synapse docker image doesn't already provide.
 

--- a/Design/Design - 188663-disable-encryption.txt
+++ b/Design/Design - 188663-disable-encryption.txt
@@ -1,0 +1,30 @@
+188663-disable-encryption
+=================================================================
+
+To minimise the merge maintenance that this solution introduces, I was initially going to do the third party rules impl (see https://github.com/matrix-org/synapse/issues/4367#issuecomment-678366829 and https://github.com/matrix-org/synapse/issues/6660#issuecomment-738011092), until I saw that an additional change to rooms.py was also required.  This change could be pushed back to https://github.com/matrix-org/synapse and potentially address https://github.com/matrix-org/synapse/issues/4401. 
+
+Based on https://github.com/matrix-org/synapse/issues/4367#issuecomment-452772632, encryption was disabled by setting the required power level to enable encryption for a room to be an impossible value, when creating a new room.  Noting that this means the disabling of encryption will only affect rooms created after this change.  It will also not affect rooms created by other servers, if federation is enabled.
+ 
+Based on https://github.com/matrix-org/synapse/issues/4367#issuecomment-634219592, RoomEncryption events were stripped, logged and ignored.
+
+Both of the above two changes are conditional based on a new homeserver.yaml configuration value named "encryption_enabled", which defaults to true, so existing functionality is not affected.
+
+Based on
+1. https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md#disabling-encryption-by-default
+2. https://github.com/matrix-org/matrix-react-sdk/pull/4605/files
+the /.well-known/matrix/client was updated to indicate to clients if encryption is enabled.  Noting that as mentioned at https://github.com/vector-im/element-web/issues/14079#issuecomment-775180051, clients use the "default_server_config" -> "m.homeserver" -> "server_name" as the domain name in the lookup of /.well-known/matrix/client.  If this is different to the domain in "default_server_config" -> "m.homeserver" -> "base_url", it is suggested that your client is updated to check the "base_url" locartion if the well-known config is not found for "server_name".
+
+These changes to the source code were applied to the synapse docker image, by copying the modified source over the top of the existing files.  This method only works if the changes made to the source code don't introduce new dependencies, that the synapse docker image doesn't already provide.
+
+
+Testing performed
+=================
+1. With no encryption_enabled value in the homeservice.yaml file, confirmed that https://pegacorn-communicate-roomserver.site-a:30880/.well-known/matrix/client returned "io.element.e2ee":{"default":"true"}
+2. With encryption_enabled: false in the homeservice.yaml file, confirmed that
+2.1 https://pegacorn-communicate-roomserver.site-a:30880/.well-known/matrix/client returned "io.element.e2ee":{"default":"false"}
+2.2 In element web created a new private room with encryption enabled ... confirmed that
+2.2.1 Room -> Settings -> Security & Privacy -> Encrypted is disabled
+2.2.2 In the synapse server logs saw:
+2.2.2.1 synapse.handlers.room - 906 - INFO - POST-739 - Removed RoomEncryption event for room_id=![room_id]:[homeserver server_name] created by @[user_id]:[homeserver server_name]
+2.2.2.2 synapse.handlers.room - 952 - DEBUG - POST-739 - power_level_content['events'][EventTypes.RoomEncryption]=101 for room_id=![room_id]:[homeserver server_name] created by @[user_id]:[homeserver server_name]
+2.2.2.3 Could see the unencrypted message sent in the room: synapse.storage.SQL - 306 - DEBUG - persist_events-7 - [SQL values] {persist_events-357} (... "type":"m.room.message","room_id":"![room_id]:[homeserver server_name]","sender":"@[user_id]:[homeserver server_name]","content":{"msgtype":"m.text","body":"my test message"} ...)

--- a/Design/Design - pegacorn-communicate-roomserver.txt
+++ b/Design/Design - pegacorn-communicate-roomserver.txt
@@ -80,8 +80,8 @@ Build and deploy
 ================
 E:
 cd \dev\github\pegacorn-communicate-serverside-roomserver
-OLD NO LONGER REQUIRED docker build --rm -t pegacorn/pegacorn-communicate-roomserver:1.0 .
-\helm\helm upgrade pegacorn-communicate-roomserver-site-a --install --namespace site-a --set serviceName=pegacorn-communicate-roomserver,basePort=30880,hostPathCerts=/data/certificates,hostPath=/data/synapse,allowPasswordLogin=true,imageTag=v1.26.0,matrixServerName=chs.local.gov.au,numOfPods=1 helm
+docker build --rm -t pegacorn/pegacorn-communicate-roomserver:1.0.0-snapshot .
+\helm\helm upgrade pegacorn-communicate-roomserver-site-a --install --namespace site-a --set serviceName=pegacorn-communicate-roomserver,basePort=30880,hostPathCerts=/data/certificates,hostPath=/data/synapse,imageTag=1.0.0-snapshot,matrixServerName=chs.local.gov.au,matrixLogLevel=DEBUG,allowPasswordLogin=true,numOfPods=1 helm
 
 On the container these are the file locations:
 	certificates - /var/lib/synapse/certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
-FROM matrixdotorg/synapse:latest
+FROM matrixdotorg/synapse:v1.26.0
 
-ENV SYNAPSE_CONFIG_PATH /var/lib/synapse/config
+# Copy the pegacorn python source code over the synapse source code
+# This method only works if the changes made to the source code don't introduce new dependencies, 
+# that the synapse docker image doesn't already provide.
+COPY ./synapse/config/server.py /usr/local/lib/python3.8/site-packages/synapse/config/server.py
+COPY ./synapse/handlers/room.py /usr/local/lib/python3.8/site-packages/synapse/handlers/room.py
+COPY ./synapse/rest/well_known.py /usr/local/lib/python3.8/site-packages/synapse/rest/well_known.py

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -2394,7 +2394,7 @@ spam_checker:
 
 ## Rooms ##
 
-# Controls whether locally-created rooms allow encryption.
+# Controls whether locally-created rooms (e.g. rooms created on this matrix server) allow encryption.
 #
 # Defaults to 'true'.
 #
@@ -2417,6 +2417,8 @@ spam_checker:
 #
 # Note that this option will only affect rooms created after it is set. It
 # will also not affect rooms created by other servers.
+#
+# This value is ignored if encryption_enabled is false
 #
 #encryption_enabled_by_default_for_room_type: invite
 

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -2394,6 +2394,15 @@ spam_checker:
 
 ## Rooms ##
 
+# Controls whether locally-created rooms allow encryption.
+#
+# Defaults to 'true'.
+#
+# Note that this option will only affect rooms created after it is set. It
+# will also not affect rooms created by other servers.
+# encryption_enabled: true
+
+
 # Controls whether locally-created rooms should be end-to-end encrypted by
 # default.
 #

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -93,8 +93,29 @@ spec:
             echo START of /var/lib/synapse/config/homeserver.yaml file content;
             echo ' ';
             cat /var/lib/synapse/config/homeserver.yaml;
+h            echo ' ';
+            echo END of /var/lib/synapse/config/homeserver.yaml file content;
+            echo Updating /var/lib/synapse/config/log.config file; 
+            [ -e /var/lib/synapse/config/log-with-placeholders.config ] || cp /var/lib/synapse/config/log.config /var/lib/synapse/config/log-with-placeholders.config;
+            /bin/cp -f /var/lib/synapse/config/log-with-placeholders.config /var/lib/synapse/config/log.config;
+            sed -i \"s/INFO/{{ .Values.matrixLogLevel | default "INFO" }}/\" /var/lib/synapse/config/log.config;
+            echo START of /var/lib/synapse/config/log.config file content;
             echo ' ';
-            echo END of /var/lib/synapse/config/homeserver.yaml file content;"
+            cat /var/lib/synapse/config/log.config;
+            echo ' ';
+            echo END of /var/lib/synapse/config/log.config file content;
+        {{- if (.Values.externalDnsEntry) }} 
+            echo '127.0.0.1 {{ .Values.externalDnsEntry }}' >> /etc/hosts;
+            echo START of /etc/hosts file content;
+            echo ' ';
+            cat /etc/hosts;
+            echo ' ';
+            echo END of /etc/hosts file content;
+            echo no_proxy=${no_proxy};
+            export no_proxy={{ .Values.externalDnsEntry }};
+            echo no_proxy=${no_proxy};
+        {{- end }}
+            "
         volumeMounts:
         - name: config
           mountPath: /var/lib/synapse/config
@@ -165,7 +186,7 @@ spec:
         resources:
           requests:
             memory: "{{ (add 128 .Values.jvmMaxHeapSizeMB) | default 2048 }}Mi"
-        image: matrixdotorg/synapse:{{ .Values.imageTag }}            
+        image: pegacorn/pegacorn-communicate-roomserver:{{ .Values.imageTag }}            
         imagePullPolicy: {{ .Values.imagePullPolicy | default "IfNotPresent" }}
         livenessProbe:
           httpGet:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
             echo START of /var/lib/synapse/config/homeserver.yaml file content;
             echo ' ';
             cat /var/lib/synapse/config/homeserver.yaml;
-h            echo ' ';
+            echo ' ';
             echo END of /var/lib/synapse/config/homeserver.yaml file content;
             echo Updating /var/lib/synapse/config/log.config file; 
             [ -e /var/lib/synapse/config/log-with-placeholders.config ] || cp /var/lib/synapse/config/log.config /var/lib/synapse/config/log-with-placeholders.config;

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -174,6 +174,9 @@ class ServerConfig(Config):
         # false only if we are updating the user directory in a worker
         self.update_user_directory = config.get("update_user_directory", True)
 
+        # Controls whether locally-created rooms allow encryption.
+        self.encryption_enabled = config.get("encryption_enabled", True)
+
         # whether to enable the media repository endpoints. This should be set
         # to false if the media repository is running as a separate endpoint;
         # doing so ensures that we will not run cache cleanup jobs on the

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -174,7 +174,7 @@ class ServerConfig(Config):
         # false only if we are updating the user directory in a worker
         self.update_user_directory = config.get("update_user_directory", True)
 
-        # Controls whether locally-created rooms allow encryption.
+        # Controls whether locally-created rooms (e.g. rooms created on this matrix server) allow encryption.
         self.encryption_enabled = config.get("encryption_enabled", True)
 
         # whether to enable the media repository endpoints. This should be set

--- a/synapse/rest/well_known.py
+++ b/synapse/rest/well_known.py
@@ -41,6 +41,13 @@ class WellKnownBuilder:
                 "base_url": self._config.default_identity_server
             }
 
+        # Indicate to clients if encryption is enabled.  Based on
+        # 1. https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md#disabling-encryption-by-default
+        # 2. https://github.com/matrix-org/matrix-react-sdk/pull/4605/files
+        result["io.element.e2ee"] = {
+            "default": str(self._config.encryption_enabled).lower()
+        }
+
         return result
 
 

--- a/tests/rest/test_well_known.py
+++ b/tests/rest/test_well_known.py
@@ -38,5 +38,6 @@ class WellKnownTests(unittest.HomeserverTestCase):
             {
                 "m.homeserver": {"base_url": "https://tesths"},
                 "m.identity_server": {"base_url": "https://testis"},
+                "io.element.e2ee": {"default": "true"},
             },
         )


### PR DESCRIPTION
… configuration value named "encryption_enabled", which defaults to true, so existing functionality is not affected.

To minimise the merge maintenance that this solution introduces, I was initially going to do the third party rules impl (see https://github.com/matrix-org/synapse/issues/4367#issuecomment-678366829 and https://github.com/matrix-org/synapse/issues/6660#issuecomment-738011092), until I saw that an additional change to rooms.py was also required.  This change could be pushed back to https://github.com/matrix-org/synapse and potentially address https://github.com/matrix-org/synapse/issues/4401. 

Based on https://github.com/matrix-org/synapse/issues/4367#issuecomment-452772632, encryption was disabled by setting the required power level to enable encryption for a room to be an impossible value, when creating a new room.  Noting that this means the disabling of encryption will only affect rooms created after this change.  It will also not affect rooms created by other servers, if federation is enabled.
 
Based on https://github.com/matrix-org/synapse/issues/4367#issuecomment-634219592, RoomEncryption events were stripped, logged and ignored.

Both of the above two changes are conditional based on a new homeserver.yaml configuration value named "encryption_enabled", which defaults to true, so existing functionality is not affected.

Based on
1. https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md#disabling-encryption-by-default
2. https://github.com/matrix-org/matrix-react-sdk/pull/4605/files
the /.well-known/matrix/client was updated to indicate to clients if encryption is enabled.  Noting that as mentioned at https://github.com/vector-im/element-web/issues/14079#issuecomment-775180051, clients use the "default_server_config" -> "m.homeserver" -> "server_name" as the domain name in the lookup of /.well-known/matrix/client.  If this is different to the domain in "default_server_config" -> "m.homeserver" -> "base_url", it is suggested that your client is updated to check the "base_url" locartion if the well-known config is not found for "server_name".

These changes to the source code were applied to the synapse docker image, by copying the modified source over the top of the existing files.  This method only works if the changes made to the source code don't introduce new dependencies, that the synapse docker image doesn't already provide.


Testing performed
=================
1. With no encryption_enabled value in the homeservice.yaml file, confirmed that https://pegacorn-communicate-roomserver.site-a:30880/.well-known/matrix/client returned "io.element.e2ee":{"default":"true"}
2. With encryption_enabled: false in the homeservice.yaml file, confirmed that
2.1 https://pegacorn-communicate-roomserver.site-a:30880/.well-known/matrix/client returned "io.element.e2ee":{"default":"false"}
2.2 In element web created a new private room with encryption enabled ... confirmed that
2.2.1 Room -> Settings -> Security & Privacy -> Encrypted is disabled
2.2.2 In the synapse server logs saw:
2.2.2.1 synapse.handlers.room - 906 - INFO - POST-739 - Removed RoomEncryption event for room_id=![room_id]:[homeserver server_name] created by @[user_id]:[homeserver server_name]
2.2.2.2 synapse.handlers.room - 952 - DEBUG - POST-739 - power_level_content['events'][EventTypes.RoomEncryption]=101 for room_id=![room_id]:[homeserver server_name] created by @[user_id]:[homeserver server_name]
2.2.2.3 Could see the unencrypted message sent in the room: synapse.storage.SQL - 306 - DEBUG - persist_events-7 - [SQL values] {persist_events-357} (... "type":"m.room.message","room_id":"![room_id]:[homeserver server_name]","sender":"@[user_id]:[homeserver server_name]","content":{"msgtype":"m.text","body":"my test message"} ...)