### PR TITLE
219811-Remove-the-I-trust-server-prompt-screen

### DIFF
--- a/Design/Design - pegacorn-communicate-roomserver.txt
+++ b/Design/Design - pegacorn-communicate-roomserver.txt
@@ -81,7 +81,7 @@ Build and deploy
 E:
 cd \dev\github\pegacorn-communicate-serverside-roomserver
 docker build --rm --build-arg IMAGE_BUILD_TIMESTAMP="%date% %time%" -t pegacorn-communicate-roomserver:1.0.0-snapshot .
-\helm\helm upgrade pegacorn-communicate-roomserver-site-a --install --namespace site-a --set serviceName=pegacorn-communicate-roomserver,basePort=30880,hostPathCerts=/data/certificates,hostPath=/data/synapse,imageTag=1.0.0-snapshot,matrixServerName=chs.local.gov.au,matrixLogLevel=DEBUG,allowPasswordLogin=true,numOfPods=1 helm
+\helm\helm upgrade pegacorn-communicate-roomserver-site-a --install --namespace site-a --set serviceName=pegacorn-communicate-roomserver,basePort=30880,hostPathCerts=/data/certificates,hostPath=/data/synapse,imageTag=1.0.0-snapshot,matrixServerName=chs.local.gov.au,clientProtocolHostNameAndPorts="https://pegacorn-communicate-web.site-a:30890/",matrixLogLevel=DEBUG,allowPasswordLogin=true,numOfPods=1 helm
 
 On the container these are the file locations:
 	certificates - /var/lib/synapse/certificates

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -90,6 +90,21 @@ spec:
             sed -i \"s/<macaroonSecretKey>/${MACAROON_SECRET_KEY}/\" /var/lib/synapse/config/homeserver.yaml;
             sed -i \"s/<formSecret>/${FORM_SECRET}/\" /var/lib/synapse/config/homeserver.yaml;
             sed -i \"s/<AllowPasswordLogin>/{{ .Values.allowPasswordLogin | default "false" }}/\" /var/lib/synapse/config/homeserver.yaml;
+        {{- if (.Values.turnURLs) }} 
+            sed -i '/turn_uris:/ a turn_allow_guests: {{ .Values.turnAllowGuests | default "true" }} \\' /var/lib/synapse/config/homeserver.yaml;
+            sed -i '/turn_uris:/ a turn_shared_secret: \"{{ .Values.turnSharedSecret }}\" \\' /var/lib/synapse/config/homeserver.yaml;
+            sed -i '/turn_uris:/ a turn_user_lifetime: {{ .Values.turnUserLifetime | default "1h" }} \\' /var/lib/synapse/config/homeserver.yaml;
+          {{- range (split "^" .Values.turnURLs) }}
+            sed -i '/turn_uris:/ a\\  - \"{{ . }}\" ' /var/lib/synapse/config/homeserver.yaml;            
+          {{- end }}
+            sed -i '/#turn_uris:/ a turn_uris: ' /var/lib/synapse/config/homeserver.yaml;
+        {{- end }}
+        {{- if (.Values.clientProtocolHostNameAndPorts) }} 
+          {{- range (split "^" .Values.clientProtocolHostNameAndPorts) }}
+            sed -i '/client_whitelist:/ a\\      - {{ . }} ' /var/lib/synapse/config/homeserver.yaml;
+          {{- end }}
+            sed -i '/#client_whitelist:/ a\\    client_whitelist: ' /var/lib/synapse/config/homeserver.yaml;
+        {{- end }}
             echo START of /var/lib/synapse/config/homeserver.yaml file content;
             echo ' ';
             cat /var/lib/synapse/config/homeserver.yaml;


### PR DESCRIPTION
Set the client_whitelist in the homeserver.yaml to be for the Lingo client channels, using ^ to separate the URLs because comma caused helm issues (even thought the comma was within double quotes);

Set the turn_uri config in the homeserver.yaml to specify the TURN server to use for Lingo voice calls;