### PR TITLE
Feature/disable default notif rules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY synapse/config/server.py /usr/local/lib/python3.8/site-packages/synapse/con
 COPY synapse/handlers/room.py /usr/local/lib/python3.8/site-packages/synapse/handlers/room.py
 COPY synapse/http/proxyagent.py /usr/local/lib/python3.8/site-packages/synapse/http/proxyagent.py
 COPY synapse/push/baserules.py /usr/local/lib/python3.8/site-packages/synapse/push/baserules.py
+COPY synapse/rest/client/v1/push_rule.py /usr/local/lib/python3.8/site-packages/synapse/rest/client/v1/push_rule.py
 
 # Install our root certificates
 COPY docker/ca-local.cer /usr/local/share/ca-certificates/ca-local.crt

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM matrixdotorg/synapse:v1.26.0
 COPY synapse/config/server.py /usr/local/lib/python3.8/site-packages/synapse/config/server.py
 COPY synapse/handlers/room.py /usr/local/lib/python3.8/site-packages/synapse/handlers/room.py
 COPY synapse/http/proxyagent.py /usr/local/lib/python3.8/site-packages/synapse/http/proxyagent.py
+COPY synapse/push/baserules.py /usr/local/lib/python3.8/site-packages/synapse/push/baserules.py
 
 # Install our root certificates
 COPY docker/ca-local.cer /usr/local/share/ca-certificates/ca-local.crt

--- a/docs/push_rules.md
+++ b/docs/push_rules.md
@@ -1,3 +1,4 @@
+
 ==================================================================================================================
                                     Push rules configurations
 ==================================================================================================================
@@ -12,11 +13,11 @@
 - `NEW_APPEND_UNDERRIDE_RULES`
 - `NEW_APPEND_OVERRIDE_RULES`
 
-3. A third implementation has been introduced where client consuming api needs to provide a list of push notifications from default notification rules such as `m.rule.tombstone` as an example would need to be passed in list format which are read to override in `roomserver/baserule.py` as well as `server.py` and `pushrules.py` in `Get, PUT` api context to always be turned off.
-override_default_push_rules: 
+3. A third implementation `BASE_CONFIGURED_OVERRIDE_RULE_IDS` has been introduced where client consuming api needs to provide a list of push notifications from default notification rules such as `m.rule.tombstone` as an example would need to be passed in list format which are read to override in `roomserver/baserule.py` as well as `server.py` and `pushrules.py` in `Get, PUT` api context to always be turned off.
+BASE_CONFIGURED_OVERRIDE_RULE_IDS: 
   - '.m.rule.tombstone'
   - '.m.rule.encrypted'
-  - '.m.rule.encrypted_room_one_to_one/'
+  - '.m.rule.encrypted_room_one_to_one'
 
-  Please look into corresponding front end applicatioon which consumes these push rules for more push rules definitions and what they mean. These push rules are either turned on, off or set to noisy in client side by default. There are other more than 10 push rules and the ones which needs to be disabled can be passed as parameter of flag `override_default_push_rules` which is `List`. Roomserver converts `override_default_push_rules` and uses configured value in `baserules.py` file to turn off push rules. Not providing any values in that list would automatically default all default push rules to matrix default ones. It also does not impact push rules specified in 2) which are controlled only by `users_new_default_push_rules` configured and combines both default rules as well as new rules configured through this flag.
+  Please look into corresponding front end applicatioon which consumes these push rules for more push rules definitions and what they mean. These push rules are either turned on, off or set to noisy in client side by default. There are other more than 10 push rules and the ones which needs to be disabled can be passed as parameter of flag `BASE_CONFIGURED_OVERRIDE_RULE_IDS` which is `List`. Roomserver converts `BASE_CONFIGURED_OVERRIDE_RULE_IDS` and uses configured value in `baserules.py` file to turn off push rules. Not providing any values in that list would automatically default all default push rules to matrix default ones. It also does not impact push rules specified in 2) which are controlled only by `users_new_default_push_rules` configured and combines both default rules as well as new rules configured through this flag.
 

--- a/docs/push_rules.md
+++ b/docs/push_rules.md
@@ -1,0 +1,22 @@
+==================================================================================================================
+                                    Push rules configurations
+==================================================================================================================
+
+1. Default Push rules are configured and populated from `baserules.py` file. These four different default push notifications configurations are set and sent to client side application which consumes rules through matrix api. These rules would apply by default only if there is no config parameter provided which is `users_new_default_push_rules`.
+- `BASE_APPEND_CONTENT_RULES`
+- `BASE_PREPEND_OVERRIDE_RULES`
+- `BASE_APPEND_OVERRIDE_RULES`
+- `BASE_APPEND_UNDERRIDE_RULES`
+
+2. As mentioned above, user can choose to have additional push rules configured by providing user id in configuration for which users need these new default configurations defined below. The flag used in homeserver config value is called `users_new_default_push_rules`. These new push rules which are under following two arrays below are also configured in `baserules.py` just as other push rules but new push rules are not applied if client does not provide list of userids. 
+- `NEW_APPEND_UNDERRIDE_RULES`
+- `NEW_APPEND_OVERRIDE_RULES`
+
+3. A third implementation has been introduced where client consuming api needs to provide a list of push notifications from default notification rules such as `m.rule.tombstone` as an example would need to be passed in list format which are read to override in `roomserver/baserule.py` as well as `server.py` and `pushrules.py` in `Get, PUT` api context to always be turned off.
+override_default_push_rules: 
+  - '.m.rule.tombstone'
+  - '.m.rule.encrypted'
+  - '.m.rule.encrypted_room_one_to_one/'
+
+  Please look into corresponding front end applicatioon which consumes these push rules for more push rules definitions and what they mean. These push rules are either turned on, off or set to noisy in client side by default. There are other more than 10 push rules and the ones which needs to be disabled can be passed as parameter of flag `override_default_push_rules` which is `List`. Roomserver converts `override_default_push_rules` and uses configured value in `baserules.py` file to turn off push rules. Not providing any values in that list would automatically default all default push rules to matrix default ones. It also does not impact push rules specified in 2) which are controlled only by `users_new_default_push_rules` configured and combines both default rules as well as new rules configured through this flag.
+

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -607,16 +607,19 @@ class ServerConfig(Config):
             users_new_default_push_rules
         )  # type: set
 
-       # List of push rules to be overridden based on config value "default_to_all_notification_rules_from_homeserver"
-        override_default_push_rules = config.get("override_default_push_rules")
+       # List of push rules in default push rules list can be overridden with flag
+       # "override_default_push_rules" so that pre configured default push rules are
+       # not enforced to client apps and handled appropriately
+        override_default_push_rules = config.get("override_default_push_rules") or []
+
+        # check if given list is valid otherwise throw exception.
+        if not isinstance(override_default_push_rules, list):
+            raise ConfigError("'override_default_push_rules' must be a list")
        
         # Turn the list into a set to improve lookup speed.
         self.override_default_push_rules = set(
             override_default_push_rules or []
         )  # type: set
-        # check if given list is valid otherwise throw exception.
-        if not isinstance(override_default_push_rules, list):
-            raise ConfigError("'override_default_push_rules' must be a list")
 
        # Whitelist of domain names that given next_link parameters must have
         next_link_domain_whitelist = config.get(

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -616,7 +616,7 @@ class ServerConfig(Config):
         )  # type: set
         # check if given list is valid otherwise throw exception.
         if not isinstance(override_default_push_rules, list):
-            raise ConfigError("rules to be turned off' must be a list")
+            raise ConfigError("'override_default_push_rules' must be a list")
 
        # Whitelist of domain names that given next_link parameters must have
         next_link_domain_whitelist = config.get(

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -617,9 +617,7 @@ class ServerConfig(Config):
             raise ConfigError("'override_default_push_rules' must be a list")
        
         # Turn the list into a set to improve lookup speed.
-        self.override_default_push_rules = set(
-            override_default_push_rules or []
-        )  # type: set
+        self.override_default_push_rules = override_default_push_rules # type : list
 
        # Whitelist of domain names that given next_link parameters must have
         next_link_domain_whitelist = config.get(

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -607,7 +607,18 @@ class ServerConfig(Config):
             users_new_default_push_rules
         )  # type: set
 
-        # Whitelist of domain names that given next_link parameters must have
+       # List of push rules to be overridden based on config value "default_to_all_notification_rules_from_homeserver"
+        override_default_push_rules = config.get("override_default_push_rules")
+       
+        # Turn the list into a set to improve lookup speed.
+        self.override_default_push_rules = set(
+            override_default_push_rules or []
+        )  # type: set
+        # check if given list is valid otherwise throw exception.
+        if not isinstance(override_default_push_rules, list):
+            raise ConfigError("rules to be turned off' must be a list")
+
+       # Whitelist of domain names that given next_link parameters must have
         next_link_domain_whitelist = config.get(
             "next_link_domain_whitelist"
         )  # type: Optional[List[str]]

--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -171,6 +171,10 @@ def changeConfiguredDefaultPushrules(r):
         r["enabled"] = False,
         r["actions"] = ["dont_notify"]
         logger.debug("Found following overridden rules in config [%s]", r)
+    elif any(id in r["rule_id"] for id in enabledPushRules):
+        r["enabled"] = True
+    elif any(id in r["rule_id"] for id in actions):
+        r["actions"] = ["notify", {"set_tweak": "highlight", "value": True}]
     
     return r
 
@@ -182,10 +186,15 @@ def changeConfiguredDefaultPushrules(r):
 
 BASE_CONFIGURED_OVERRIDE_RULE_IDS = [
     {
-        "enabled": [".m.rule.tombstone"]
+        "enabled":[".m.rule.tombstone"]
     },
     {
-        "disabled": [".m.rule.encrypted_room_one_to_one", ".m.rule.encrypted"]
+    "disabled":[
+        ".m.rule.encrypted_room_one_to_one",
+        ".m.rule.encrypted"]
+    },
+    {
+   "actions":[".m.rule.tombstone"]
     }
 ]
 
@@ -607,10 +616,13 @@ NEW_APPEND_UNDERRIDE_RULES = [
    
 enabledPushRules = []
 disabledPushRules = []
+actions = []
 for rule in BASE_CONFIGURED_OVERRIDE_RULE_IDS:
     for r in rule.get("enabled", []):
         enabledPushRules.append(r)
     for r in rule.get("disabled", []):
+        disabledPushRules.append(r)
+    for r in rule.get("actions", []):
         disabledPushRules.append(r)
 
 BASE_RULE_IDS = set()

--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -591,25 +591,25 @@ for r in BASE_APPEND_OVERRIDE_RULES:
 for r in BASE_APPEND_UNDERRIDE_RULES:
     r["priority_class"] = PRIORITY_CLASS_MAP["underride"]
     r["default"] = True
-    BASE_RULE_IDS.add(r["rule_id"])
-    default_push_rules = [".m.rule.room_one_to_one", ".m.rule.encrypted_room_one_to_one", ".m.rule.encrypted"]
+    override_config_push_rules = [".m.rule.tombstone", ".m.rule.encrypted_room_one_to_one", ".m.rule.encrypted"]
     logger.debug("Found the following override rules [%s]", r)
-    for override_rules in default_push_rules:
+    for override_rules in override_config_push_rules:
         logger.debug("base rule ids were found to be: {}".format(r))
         logger.debug("override rule ids were found to be: {}".format(override_rules))
         if override_rules in r:
-            r["actions"] = ["dont_notify"]
+            r["actions"] = "dont_notify"
             r["enabled"] = False
+    BASE_RULE_IDS.add(r["rule_id"])
 
 
 # for r in BASE_RULE_IDS:
-#     default_push_rules = [".m.rule.room_one_to_one", ".m.rule.encrypted_room_one_to_one", ".m.rule.encrypted"]
+#     override_config_push_rules = [".m.rule.room_one_to_one", ".m.rule.encrypted_room_one_to_one", ".m.rule.encrypted"]
 #     logger.debug("Found the following override rules [%s]", r)
-#     for override_rules in default_push_rules:
+#     for override_rules in override_config_push_rules:
 #         logger.debug("base rule ids were found to be: {}".format(r))
 #         logger.debug("override rule ids were found to be: {}".format(override_rules))
 #         if override_rules in r:
-#             r["actions"] = ["dont_notify"]
+#             r["actions"] = "dont_notify"
 #             r["enabled"] = False
 
 NEW_RULE_IDS = set()

--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -19,8 +19,8 @@ import copy
 from typing import Any, Dict, List
 
 from synapse.push.rulekinds import PRIORITY_CLASS_INVERSE_MAP, PRIORITY_CLASS_MAP
-# from synapse.config.server import override_default_push_rules
 
+override_config_push_rules = [".m.rule.tombstone", ".m.rule.encrypted_room_one_to_one", ".m.rule.encrypted"]
 logger = logging.getLogger("baserules")
 
 def list_with_base_rules(
@@ -576,41 +576,42 @@ BASE_RULE_IDS = set()
 for r in BASE_APPEND_CONTENT_RULES:
     r["priority_class"] = PRIORITY_CLASS_MAP["content"]
     r["default"] = True
+    # if push rules are configured then disable that push rule
+    if any(id in r["rule_id"] for id in override_config_push_rules):
+        r["enabled"] = False,
+        r["actions"] = ["dont_notify"]
+        logger.debug("Found following base append rules [%s]", r) 
     BASE_RULE_IDS.add(r["rule_id"])
 
 for r in BASE_PREPEND_OVERRIDE_RULES:
     r["priority_class"] = PRIORITY_CLASS_MAP["override"]
     r["default"] = True
+    # if push rules are configured then disable that push rule
+    if any(id in r["rule_id"] for id in override_config_push_rules):
+        r["enabled"] = False,
+        r["actions"] = ["dont_notify"]
+        logger.debug("Found following base prepend override rules [%s]", r) 
     BASE_RULE_IDS.add(r["rule_id"])
 
 for r in BASE_APPEND_OVERRIDE_RULES:
     r["priority_class"] = PRIORITY_CLASS_MAP["override"]
     r["default"] = True
+    # if push rules are configured then disable that push rule
+    if any(id in r["rule_id"] for id in override_config_push_rules):
+        r["enabled"] = False,
+        r["actions"] = ["dont_notify"]
+        logger.debug("Found the following base append override rules [%s]", r)
     BASE_RULE_IDS.add(r["rule_id"])
 
 for r in BASE_APPEND_UNDERRIDE_RULES:
     r["priority_class"] = PRIORITY_CLASS_MAP["underride"]
     r["default"] = True
-    override_config_push_rules = [".m.rule.tombstone", ".m.rule.encrypted_room_one_to_one", ".m.rule.encrypted"]
-    logger.debug("Found the following override rules [%s]", r)
-    for override_rules in override_config_push_rules:
-        logger.debug("base rule ids were found to be: {}".format(r))
-        logger.debug("override rule ids were found to be: {}".format(override_rules))
-        if override_rules in r:
-            r["actions"] = "dont_notify"
-            r["enabled"] = False
+    # if push rules are configured then disable that push rule
+    if any(id in r["rule_id"] for id in override_config_push_rules):
+        r["enabled"] = False,
+        r["actions"] = ["dont_notify"]
+        logger.debug("Found following base append underride rules [%s]", r)
     BASE_RULE_IDS.add(r["rule_id"])
-
-
-# for r in BASE_RULE_IDS:
-#     override_config_push_rules = [".m.rule.room_one_to_one", ".m.rule.encrypted_room_one_to_one", ".m.rule.encrypted"]
-#     logger.debug("Found the following override rules [%s]", r)
-#     for override_rules in override_config_push_rules:
-#         logger.debug("base rule ids were found to be: {}".format(r))
-#         logger.debug("override rule ids were found to be: {}".format(override_rules))
-#         if override_rules in r:
-#             r["actions"] = "dont_notify"
-#             r["enabled"] = False
 
 NEW_RULE_IDS = set()
 

--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -163,7 +163,7 @@ def make_base_prepend_rules(
 # checks if client has configured to have a
 # a different push notifications within "override_default_push_rules"
 # array or hardcoded values in BASE_CONFIGURED_OVERRIDE_RULE_IDS
-def applyDefaultPushrulesConfigured(rules):
+def modifyDefaultPushrulesFromConfiguredPushrules(rules):
     enabledPushrulesFromConfig = []
     pushrulesActionsFromConfig = []
     disabledPushrulesFromConfig = []
@@ -629,25 +629,25 @@ BASE_RULE_IDS = set()
 for r in BASE_APPEND_CONTENT_RULES:
     r["priority_class"] = PRIORITY_CLASS_MAP["content"]
     r["default"] = True
-    applyDefaultPushrulesConfigured(r)
+    modifyDefaultPushrulesFromConfiguredPushrules(r)
     BASE_RULE_IDS.add(r["rule_id"])
 
 for r in BASE_PREPEND_OVERRIDE_RULES:
     r["priority_class"] = PRIORITY_CLASS_MAP["override"]
     r["default"] = True
-    applyDefaultPushrulesConfigured(r)
+    modifyDefaultPushrulesFromConfiguredPushrules(r)
     BASE_RULE_IDS.add(r["rule_id"])
 
 for r in BASE_APPEND_OVERRIDE_RULES:
     r["priority_class"] = PRIORITY_CLASS_MAP["override"]
     r["default"] = True
-    applyDefaultPushrulesConfigured(r)
+    modifyDefaultPushrulesFromConfiguredPushrules(r)
     BASE_RULE_IDS.add(r["rule_id"])
 
 for r in BASE_APPEND_UNDERRIDE_RULES:
     r["priority_class"] = PRIORITY_CLASS_MAP["underride"]
     r["default"] = True
-    applyDefaultPushrulesConfigured(r)
+    modifyDefaultPushrulesFromConfiguredPushrules(r)
     BASE_RULE_IDS.add(r["rule_id"])
 
 NEW_RULE_IDS = set()

--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -22,7 +22,7 @@ from synapse.push.rulekinds import PRIORITY_CLASS_INVERSE_MAP, PRIORITY_CLASS_MA
 
 logger = logging.getLogger("baserules")
 
-def populate_disabled_pushrules_from_config(pushrules: any):
+def populate_disabled_pushrules_from_config(pushrules: List[Dict[str, Any]]):
     global BASE_CONFIGURED_OVERRIDE_RULE_IDS
     for i in pushrules:
         BASE_CONFIGURED_OVERRIDE_RULE_IDS = []
@@ -167,13 +167,13 @@ def changeConfiguredDefaultPushrules(r):
 # Default push rules can be changed from homeserver config as well
 # so based on client's preference set it to disabled, enabled, noisy
 # as necessary
-    if any(id in r["rule_id"] for id in disabledPushRules):
+    if any(id in r["rule_id"] for id in disabledPushrulesFromConfig):
         r["enabled"] = False,
         r["actions"] = ["dont_notify"]
         logger.debug("Found following overridden rules in config [%s]", r)
-    elif any(id in r["rule_id"] for id in enabledPushRules):
+    elif any(id in r["rule_id"] for id in enabledPushrulesFromConfig):
         r["enabled"] = True
-    elif any(id in r["rule_id"] for id in actions):
+    elif any(id in r["rule_id"] for id in pushrulesActionsFromConfig):
         r["actions"] = ["notify", {"set_tweak": "highlight", "value": True}]
     
     return r
@@ -614,16 +614,16 @@ NEW_APPEND_UNDERRIDE_RULES = [
 ]
 
    
-enabledPushRules = []
-disabledPushRules = []
-actions = []
+enabledPushrulesFromConfig = []
+pushrulesActionsFromConfig = []
+disabledPushrulesFromConfig = []
 for rule in BASE_CONFIGURED_OVERRIDE_RULE_IDS:
     for r in rule.get("enabled", []):
-        enabledPushRules.append(r)
+        enabledPushrulesFromConfig.append(r)
     for r in rule.get("disabled", []):
-        disabledPushRules.append(r)
+        disabledPushrulesFromConfig.append(r)
     for r in rule.get("actions", []):
-        disabledPushRules.append(r)
+        pushrulesActionsFromConfig.append(r)
 
 BASE_RULE_IDS = set()
 

--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -592,20 +592,25 @@ for r in BASE_APPEND_UNDERRIDE_RULES:
     r["priority_class"] = PRIORITY_CLASS_MAP["underride"]
     r["default"] = True
     BASE_RULE_IDS.add(r["rule_id"])
-
-
-for r in BASE_RULE_IDS:
     default_push_rules = [".m.rule.room_one_to_one", ".m.rule.encrypted_room_one_to_one", ".m.rule.encrypted"]
+    logger.debug("Found the following override rules [%s]", r)
     for override_rules in default_push_rules:
         logger.debug("base rule ids were found to be: {}".format(r))
         logger.debug("override rule ids were found to be: {}".format(override_rules))
-        if override_rules in r["rule_id"]:
-            r["actions"] = "dont_notify"
+        if override_rules in r:
+            r["actions"] = ["dont_notify"]
             r["enabled"] = False
-            #alternative approach where we try to find exact match in string
-        elif r["rule_id"].index('.m.rule.encrypted_room_one_to_one') or r["rule_id"].index('.m.rule.encrypted') or r["rule_id"].index('m.rule.tombstone'):
-            r["actions"] = "dont_notify"
-            r["enabled"] = False
+
+
+# for r in BASE_RULE_IDS:
+#     default_push_rules = [".m.rule.room_one_to_one", ".m.rule.encrypted_room_one_to_one", ".m.rule.encrypted"]
+#     logger.debug("Found the following override rules [%s]", r)
+#     for override_rules in default_push_rules:
+#         logger.debug("base rule ids were found to be: {}".format(r))
+#         logger.debug("override rule ids were found to be: {}".format(override_rules))
+#         if override_rules in r:
+#             r["actions"] = ["dont_notify"]
+#             r["enabled"] = False
 
 NEW_RULE_IDS = set()
 

--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -20,8 +20,13 @@ from typing import Any, Dict, List
 
 from synapse.push.rulekinds import PRIORITY_CLASS_INVERSE_MAP, PRIORITY_CLASS_MAP
 
-override_config_push_rules = [".m.rule.tombstone", ".m.rule.encrypted_room_one_to_one", ".m.rule.encrypted"]
 logger = logging.getLogger("baserules")
+base_rules_disabled = [".m.rule.tombstone", ".m.rule.encrypted_room_one_to_one", ".m.rule.encrypted"]
+
+def populate_disabled_pushrules_from_config(pushrules: any):
+    global base_rules_disabled
+    for i in pushrules:
+        base_rules_disabled.append(i)
 
 def list_with_base_rules(
     rawrules: List[Dict[str, Any]], use_new_defaults: bool = False
@@ -577,37 +582,38 @@ for r in BASE_APPEND_CONTENT_RULES:
     r["priority_class"] = PRIORITY_CLASS_MAP["content"]
     r["default"] = True
     # if push rules are configured then disable that push rule
-    if any(id in r["rule_id"] for id in override_config_push_rules):
+    # https://stackoverflow.com/questions/53123719/how-to-compare-two-lists-to-keep-matching-substrings
+    if any(id in r["rule_id"] for id in base_rules_disabled):
         r["enabled"] = False,
         r["actions"] = ["dont_notify"]
-        logger.debug("Found following base append rules [%s]", r) 
+        # logger.debug("Found following base append rules [%s]", r) 
     BASE_RULE_IDS.add(r["rule_id"])
 
 for r in BASE_PREPEND_OVERRIDE_RULES:
     r["priority_class"] = PRIORITY_CLASS_MAP["override"]
     r["default"] = True
     # if push rules are configured then disable that push rule
-    if any(id in r["rule_id"] for id in override_config_push_rules):
+    if any(id in r["rule_id"] for id in base_rules_disabled):
         r["enabled"] = False,
         r["actions"] = ["dont_notify"]
-        logger.debug("Found following base prepend override rules [%s]", r) 
+        # logger.debug("Found following base prepend override rules [%s]", r) 
     BASE_RULE_IDS.add(r["rule_id"])
 
 for r in BASE_APPEND_OVERRIDE_RULES:
     r["priority_class"] = PRIORITY_CLASS_MAP["override"]
     r["default"] = True
     # if push rules are configured then disable that push rule
-    if any(id in r["rule_id"] for id in override_config_push_rules):
+    if any(id in r["rule_id"] for id in base_rules_disabled):
         r["enabled"] = False,
         r["actions"] = ["dont_notify"]
-        logger.debug("Found the following base append override rules [%s]", r)
+        # logger.debug("Found the following base append override rules [%s]", r)
     BASE_RULE_IDS.add(r["rule_id"])
 
 for r in BASE_APPEND_UNDERRIDE_RULES:
     r["priority_class"] = PRIORITY_CLASS_MAP["underride"]
     r["default"] = True
     # if push rules are configured then disable that push rule
-    if any(id in r["rule_id"] for id in override_config_push_rules):
+    if any(id in r["rule_id"] for id in base_rules_disabled):
         r["enabled"] = False,
         r["actions"] = ["dont_notify"]
         logger.debug("Found following base append underride rules [%s]", r)

--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -18,7 +18,6 @@ import copy
 from typing import Any, Dict, List
 
 from synapse.push.rulekinds import PRIORITY_CLASS_INVERSE_MAP, PRIORITY_CLASS_MAP
-
 from synapse.config.server import override_default_push_rules
 
 def list_with_base_rules(
@@ -271,8 +270,6 @@ BASE_APPEND_OVERRIDE_RULES = [
     },
     {
         "rule_id": "global/override/.m.rule.tombstone",
-        "default": False,
-        "enabled": False,
         "conditions": [
             {
                 "kind": "event_match",
@@ -287,7 +284,7 @@ BASE_APPEND_OVERRIDE_RULES = [
                 "_id": "_tombstone_statekey",
             },
         ],
-        "actions": ["dont_notify"],
+        "actions": ["notify", {"set_tweak": "highlight", "value": True}],
     },
     {
         "rule_id": "global/override/.m.rule.reaction",
@@ -391,7 +388,11 @@ NEW_APPEND_OVERRIDE_RULES = [
                 "_id": "_tombstone_statekey",
             },
         ],
-        "actions": ["dont_notify"],
+        "actions": [
+            "notify",
+            {"set_tweak": "sound", "value": "default"},
+            {"set_tweak": "highlight"},
+        ],
     },
     {
         "rule_id": "global/override/.m.rule.roomnotif",
@@ -469,8 +470,6 @@ BASE_APPEND_UNDERRIDE_RULES = [
     # but are encrypted (e.g. m.call.*)...
     {
         "rule_id": "global/underride/.m.rule.encrypted_room_one_to_one",
-         "default": False,
-         "enabled": True,
         "conditions": [
             {"kind": "room_member_count", "is": "2", "_id": "member_count"},
             {
@@ -496,14 +495,12 @@ BASE_APPEND_UNDERRIDE_RULES = [
                 "_id": "_message",
             }
         ],
-        "actions": ["dont_notify"],
+        "actions": ["notify", {"set_tweak": "highlight", "value": False}],
     },
     # XXX: this is going to fire for events which aren't m.room.messages
     # but are encrypted (e.g. m.call.*)...
     {
         "rule_id": "global/underride/.m.rule.encrypted",
-        "default": False,
-        "enabled": True,
         "conditions": [
             {
                 "kind": "event_match",
@@ -512,7 +509,7 @@ BASE_APPEND_UNDERRIDE_RULES = [
                 "_id": "_encrypted",
             }
         ],
-        "actions": ["dont_notify"],
+        "actions": ["notify", {"set_tweak": "highlight", "value": False}],
     },
     {
         "rule_id": "global/underride/.im.vector.jitsi",
@@ -593,17 +590,17 @@ for r in BASE_APPEND_UNDERRIDE_RULES:
     r["default"] = True
     BASE_RULE_IDS.add(r["rule_id"])
 
-if len(override_default_push_rules) == 0:
-    for r in BASE_RULE_IDS:
-        for override_rules in override_default_push_rules:
-            if override_rules in r["rule_id"]
-            r["default"] = False
-            r["actions"] = "dont_notify"
-            "m.rule.tombstone" in r["rule_id"]
-            #alternative approach where we try to find exact match in string
-            elif r["rule_id"].index('.m.rule.encrypted_room_one_to_one') or r["rule_id"].index('.m.rule.encrypted') or r["rule_id"].index('m.rule.tombstone'):
-                r["enabled"] = False
-                r["default"] = False
+
+for r in BASE_RULE_IDS:
+    for override_rules in override_default_push_rules:
+        if override_rules in r["rule_id"]
+        r["actions"] = "dont_notify"
+        #alternative approach where we try to find exact match in string
+        elif r["rule_id"].index('.m.rule.encrypted_room_one_to_one') or r["rule_id"].index('.m.rule.encrypted') or r["rule_id"].index('m.rule.tombstone'):
+        r["enabled"] = False
+        r["actions"] = "dont_notify"
+        logger.debug("base rule ids were found to be: {}", ).format(r)
+        logger.debug("override rule ids were found to be: {}", ).format(override_rules)
 
 NEW_RULE_IDS = set()
 

--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -23,10 +23,10 @@ from synapse.push.rulekinds import PRIORITY_CLASS_INVERSE_MAP, PRIORITY_CLASS_MA
 logger = logging.getLogger("baserules")
 
 def populate_disabled_pushrules_from_config(pushrules: any):
-    global BASE_RULES_CONFIGURED_DEFAULTS
+    global BASE_CONFIGURED_OVERRIDE_RULE_IDS
     for i in pushrules:
-        BASE_RULES_CONFIGURED_DEFAULTS = []
-        BASE_RULES_CONFIGURED_DEFAULTS.append(i)
+        BASE_CONFIGURED_OVERRIDE_RULE_IDS = []
+        BASE_CONFIGURED_OVERRIDE_RULE_IDS.append(i)
 
 def list_with_base_rules(
     rawrules: List[Dict[str, Any]], use_new_defaults: bool = False
@@ -160,9 +160,9 @@ def make_base_prepend_rules(
 
     return rules
 
-# checks if client has decided to to have
+# checks if client has configured to have a
 # a different push notifications within "override_default_push_rules"
-# array or even hardcoded ones defined in BASE_RULES_CONFIGURED_DEFAULTS
+# array or hardcoded values in BASE_CONFIGURED_OVERRIDE_RULE_IDS
 def changeConfiguredDefaultPushrules(r):
 # Default push rules can be changed from homeserver config as well
 # so based on client's preference set it to disabled, enabled, noisy
@@ -180,9 +180,9 @@ def changeConfiguredDefaultPushrules(r):
 # rules be set to noisy, on, off as required
 
 
-BASE_RULES_CONFIGURED_DEFAULTS = [
+BASE_CONFIGURED_OVERRIDE_RULE_IDS = [
     {
-        "enabled": ["m.rule.tombstone"]
+        "enabled": [".m.rule.tombstone"]
     },
     {
         "disabled": [".m.rule.encrypted_room_one_to_one", ".m.rule.encrypted"]
@@ -607,7 +607,7 @@ NEW_APPEND_UNDERRIDE_RULES = [
    
 enabledPushRules = []
 disabledPushRules = []
-for rule in BASE_RULES_CONFIGURED_DEFAULTS:
+for rule in BASE_CONFIGURED_OVERRIDE_RULE_IDS:
     for r in rule.get("enabled", []):
         enabledPushRules.append(r)
     for r in rule.get("disabled", []):

--- a/synapse/push/baserules.py
+++ b/synapse/push/baserules.py
@@ -14,11 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import copy
 from typing import Any, Dict, List
 
 from synapse.push.rulekinds import PRIORITY_CLASS_INVERSE_MAP, PRIORITY_CLASS_MAP
-from synapse.config.server import override_default_push_rules
+# from synapse.config.server import override_default_push_rules
+
+logger = logging.getLogger("baserules")
 
 def list_with_base_rules(
     rawrules: List[Dict[str, Any]], use_new_defaults: bool = False
@@ -592,15 +595,17 @@ for r in BASE_APPEND_UNDERRIDE_RULES:
 
 
 for r in BASE_RULE_IDS:
-    for override_rules in override_default_push_rules:
-        if override_rules in r["rule_id"]
-        r["actions"] = "dont_notify"
-        #alternative approach where we try to find exact match in string
+    default_push_rules = [".m.rule.room_one_to_one", ".m.rule.encrypted_room_one_to_one", ".m.rule.encrypted"]
+    for override_rules in default_push_rules:
+        logger.debug("base rule ids were found to be: {}".format(r))
+        logger.debug("override rule ids were found to be: {}".format(override_rules))
+        if override_rules in r["rule_id"]:
+            r["actions"] = "dont_notify"
+            r["enabled"] = False
+            #alternative approach where we try to find exact match in string
         elif r["rule_id"].index('.m.rule.encrypted_room_one_to_one') or r["rule_id"].index('.m.rule.encrypted') or r["rule_id"].index('m.rule.tombstone'):
-        r["enabled"] = False
-        r["actions"] = "dont_notify"
-        logger.debug("base rule ids were found to be: {}", ).format(r)
-        logger.debug("override rule ids were found to be: {}", ).format(override_rules)
+            r["actions"] = "dont_notify"
+            r["enabled"] = False
 
 NEW_RULE_IDS = set()
 

--- a/synapse/rest/client/v1/push_rule.py
+++ b/synapse/rest/client/v1/push_rule.py
@@ -195,8 +195,7 @@ class PushRuleRestServlet(RestServlet):
                     rule_ids = NEW_RULE_IDS
                 elif self._users_override_default_push_rules:
                     # make rule ids that are not provided in config "_users_override_default_push_rules" list
-                    # rules that are to override matrix default push rules are defined in homeserver 
-                    # with config parameter '_users_override_default_push_rules'
+                    # rules that are in homeserver config are supposed to be disabled(off)
                     rule_ids = [rule_id for rule_id in BASE_RULE_IDS if not any(id in rule_id for id in self._users_override_default_push_rules)]
                 else:
                     rule_ids = BASE_RULE_IDS

--- a/synapse/rest/client/v1/push_rule.py
+++ b/synapse/rest/client/v1/push_rule.py
@@ -193,6 +193,11 @@ class PushRuleRestServlet(RestServlet):
             if is_default_rule:
                 if user_id in self._users_new_default_push_rules:
                     rule_ids = NEW_RULE_IDS
+                elif self._users_override_default_push_rules:
+                    # make rule ids that are not provided in config "_users_override_default_push_rules" list
+                    # rules that are to override matrix default push rules are defined in homeserver 
+                    # with config parameter '_users_override_default_push_rules'
+                    rule_ids = [rule_id for rule_id in BASE_RULE_IDS if not any(id in rule_id for id in self._users_override_default_push_rules)]
                 else:
                     rule_ids = BASE_RULE_IDS
 

--- a/synapse/rest/client/v1/push_rule.py
+++ b/synapse/rest/client/v1/push_rule.py
@@ -194,9 +194,14 @@ class PushRuleRestServlet(RestServlet):
                 if user_id in self._users_new_default_push_rules:
                     rule_ids = NEW_RULE_IDS
                 elif self._users_override_default_push_rules:
-                    # make rule ids that are not provided in config "_users_override_default_push_rules" list
-                    # rules that are in homeserver config are supposed to be disabled(off)
-                    rule_ids = [rule_id for rule_id in BASE_RULE_IDS if not any(id in rule_id for id in self._users_override_default_push_rules)]
+                    # If client has configured default push rules in homeserver config
+                    # then do not allow changing those push rules setting defaults by
+                    # checking them through. In this case it will throw 500 response 
+                    # while user tries to change push rules
+                    pushrules_configured_to_override_default = set()
+                    for rule in self._users_override_default_push_rules:
+                        pushrules_configured_to_override_default = rule.get("enabled", []) + rule.get("disabled", []) + rule.get("actions", [])
+                    rule_ids = [rule_id for rule_id in BASE_RULE_IDS if not any(id in rule_id for id in pushrules_configured_to_override_default)]
                 else:
                     rule_ids = BASE_RULE_IDS
 

--- a/synapse/rest/client/v1/push_rule.py
+++ b/synapse/rest/client/v1/push_rule.py
@@ -161,19 +161,6 @@ class PushRuleRestServlet(RestServlet):
         self.notifier.on_new_event("push_rules_key", stream_id, users=[user_id])
 
     async def set_rule_attr(self, user_id, spec, val):
-     
-    # When user decides to not apply default push rules reset array for base_rule_ids as not every server/client
-    # Base rules is going to be the difference of list
-    push_rules_must_be_enabled = False
-    for findDisabledRules in self._users_disabled_push_rules:
-    for baseRule in BASE_RULE_IDS:
-    if baseRule.find(findDisabledRules.rule_id) != -1:
-    push_rules_must_be_enabled = True
-    if push_rules_must_be_enabled:
-    baseRule
-    baseRules["default"] = False
-    BASE_RULE_IDS["actions"] = "dont_notify"
-
         if spec["attr"] not in ("enabled", "actions"):
             # for the sake of potential future expansion, shouldn't report
             # 404 in the case of an unknown request so check it corresponds to
@@ -189,8 +176,6 @@ class PushRuleRestServlet(RestServlet):
         if spec["attr"] == "enabled":
             if isinstance(val, dict) and "enabled" in val:
                 val = val["enabled"]
-                if _users_override_default_push_rules:
-                if spec["attr"] == not attr["enabled"]
             if not isinstance(val, bool):
                 # Legacy fallback
                 # This should *actually* take a dict, but many clients pass

--- a/synapse/rest/client/v1/push_rule.py
+++ b/synapse/rest/client/v1/push_rule.py
@@ -45,6 +45,7 @@ class PushRuleRestServlet(RestServlet):
         self._is_worker = hs.config.worker_app is not None
 
         self._users_new_default_push_rules = hs.config.users_new_default_push_rules
+        self._users_override_default_push_rules = hs.config.override_default_push_rules
 
     async def on_PUT(self, request, path):
         if self._is_worker:
@@ -160,6 +161,19 @@ class PushRuleRestServlet(RestServlet):
         self.notifier.on_new_event("push_rules_key", stream_id, users=[user_id])
 
     async def set_rule_attr(self, user_id, spec, val):
+     
+    # When user decides to not apply default push rules reset array for base_rule_ids as not every server/client
+    # Base rules is going to be the difference of list
+    push_rules_must_be_enabled = False
+    for findDisabledRules in self._users_disabled_push_rules:
+    for baseRule in BASE_RULE_IDS:
+    if baseRule.find(findDisabledRules.rule_id) != -1:
+    push_rules_must_be_enabled = True
+    if push_rules_must_be_enabled:
+    baseRule
+    baseRules["default"] = False
+    BASE_RULE_IDS["actions"] = "dont_notify"
+
         if spec["attr"] not in ("enabled", "actions"):
             # for the sake of potential future expansion, shouldn't report
             # 404 in the case of an unknown request so check it corresponds to
@@ -175,6 +189,8 @@ class PushRuleRestServlet(RestServlet):
         if spec["attr"] == "enabled":
             if isinstance(val, dict) and "enabled" in val:
                 val = val["enabled"]
+                if _users_override_default_push_rules:
+                if spec["attr"] == not attr["enabled"]
             if not isinstance(val, bool):
                 # Legacy fallback
                 # This should *actually* take a dict, but many clients pass

--- a/synapse/storage/databases/main/push_rule.py
+++ b/synapse/storage/databases/main/push_rule.py
@@ -103,6 +103,7 @@ class PushRulesWorkerStore(
         )
 
         self._users_new_default_push_rules = hs.config.users_new_default_push_rules
+        self._users_override_default_push_rules = hs.config.override_default_push_rules
 
     @abc.abstractmethod
     def get_max_push_rules_stream_id(self):


### PR DESCRIPTION
This pull request looks at disabling default push rules which are not wanted to by clients side of application. At the moment it tries to configure and use configured values to disable push notifications. Ultimately idea is to be able to disable, enable notifications from homeserver.yaml configuration flag.
188497 - Web: As an Authenticated Practitioner, I should be able to personalise the Notification Settings, so that I can control certain system behaviours that will maximise my user experience
